### PR TITLE
Fixing memory leak.

### DIFF
--- a/organisations/handlers.go
+++ b/organisations/handlers.go
@@ -189,7 +189,7 @@ func (h *OrganisationsHandler) getOrganisationViaConceptsAPI(uuid string, transI
 	request.Header.Set("X-Request-Id", transID)
 	resp, err := h.client.Do(request)
 	if err != nil {
-		msg := fmt.Sprintf("request to %s returned status: %d", reqURL, resp.StatusCode)
+		msg := fmt.Sprintf("request to %s was unsuccessful", reqURL)
 		logger.WithError(err).WithUUID(uuid).WithTransactionID(transID).Error(msg)
 		return org, false, err
 	}
@@ -199,6 +199,7 @@ func (h *OrganisationsHandler) getOrganisationViaConceptsAPI(uuid string, transI
 
 	conceptsApiResponse := ConceptApiResponse{}
 	body, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
 	if err != nil {
 		msg := fmt.Sprintf("failed to read response body: %v", resp.Body)
 		logger.WithError(err).WithUUID(uuid).WithTransactionID(transID).Error(msg)

--- a/organisations/handlers.go
+++ b/organisations/handlers.go
@@ -199,12 +199,15 @@ func (h *OrganisationsHandler) getOrganisationViaConceptsAPI(uuid string, transI
 
 	conceptsApiResponse := ConceptApiResponse{}
 	body, err := ioutil.ReadAll(resp.Body)
-	defer resp.Body.Close()
+
 	if err != nil {
 		msg := fmt.Sprintf("failed to read response body: %v", resp.Body)
 		logger.WithError(err).WithUUID(uuid).WithTransactionID(transID).Error(msg)
 		return org, false, err
 	}
+
+	defer resp.Body.Close()
+
 	if err = json.Unmarshal(body, &conceptsApiResponse); err != nil {
 		msg := fmt.Sprintf("failed to unmarshal response body: %v", body)
 		logger.WithError(err).WithUUID(uuid).WithTransactionID(transID).Error(msg)


### PR DESCRIPTION
Fixing memory leak very similar to this one:
Financial-Times/public-things-api@fdae1d1

The fix for public-organisations-api is to close the response once the body is read.

Also changed logging message to be analogous to the one in public-things-api.